### PR TITLE
IDVA6-1106: Implement pagination on invites 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <encryption-java-library.version>2.0.3</encryption-java-library.version>
         <rest-service-common-library-version>2.0.2</rest-service-common-library-version>
-        <private-api-sdk-java.version>4.0.135</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.138</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <api-security-java-version>2.0.4</api-security-java-version>
         <org.mapstruct.version>1.6.0.Beta2</org.mapstruct.version>

--- a/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociations.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociations.java
@@ -16,8 +16,14 @@ import uk.gov.companieshouse.accounts.association.service.EmailService;
 import uk.gov.companieshouse.accounts.association.service.UsersService;
 import uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil;
 import uk.gov.companieshouse.api.accounts.associations.api.UserCompanyAssociationsInterface;
-import uk.gov.companieshouse.api.accounts.associations.model.*;
+import uk.gov.companieshouse.api.accounts.associations.model.Association;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.ApprovalRouteEnum;
+import uk.gov.companieshouse.api.accounts.associations.model.AssociationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.InvitationRequestBodyPost;
+import uk.gov.companieshouse.api.accounts.associations.model.InvitationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.RequestBodyPost;
+import uk.gov.companieshouse.api.accounts.associations.model.RequestBodyPut;
+import uk.gov.companieshouse.api.accounts.associations.model.ResponseBodyPost;
 import uk.gov.companieshouse.api.accounts.user.model.User;
 import uk.gov.companieshouse.api.company.CompanyDetails;
 import uk.gov.companieshouse.logging.Logger;
@@ -143,7 +149,17 @@ public class UserCompanyAssociations implements UserCompanyAssociationsInterface
     }
 
     @Override
-    public ResponseEntity<InvitationsList> getInvitationsForAssociation(final String xRequestId, final String associationId) {
+    public ResponseEntity<InvitationsList> getInvitationsForAssociation(final String xRequestId, final String associationId, final Integer pageIndex, final Integer itemsPerPage) {
+        if (pageIndex < 0) {
+            LOG.error("pageIndex was less then 0");
+            throw new BadRequestRuntimeException("Please check the request and try again");
+        }
+
+        if (itemsPerPage <= 0) {
+            LOG.error("itemsPerPage was less then 0");
+            throw new BadRequestRuntimeException("Please check the request and try again");
+        }
+
         final Optional<AssociationDao> associationDaoOptional = associationsService.findAssociationDaoById(associationId);
         if (associationDaoOptional.isEmpty()) {
             LOG.error(String.format("%s: Could not find association %s in user_company_associations.", xRequestId, associationId));
@@ -151,7 +167,7 @@ public class UserCompanyAssociations implements UserCompanyAssociationsInterface
         }
 
         final AssociationDao associationDao = associationDaoOptional.get();
-        final InvitationsList invitations = associationsService.fetchInvitations(associationDao);
+        final InvitationsList invitations = associationsService.fetchInvitations(associationDao, pageIndex, itemsPerPage);
 
         return new ResponseEntity<>(invitations, HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/companieshouse/accounts/association/utils/MapperUtil.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/utils/MapperUtil.java
@@ -1,9 +1,5 @@
 package uk.gov.companieshouse.accounts.association.utils;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
@@ -11,9 +7,12 @@ import uk.gov.companieshouse.accounts.association.service.CompanyService;
 import uk.gov.companieshouse.accounts.association.service.UsersService;
 import uk.gov.companieshouse.api.accounts.associations.model.Association;
 import uk.gov.companieshouse.api.accounts.associations.model.AssociationsList;
-import uk.gov.companieshouse.api.accounts.associations.model.AssociationsListLinks;
 import uk.gov.companieshouse.api.accounts.associations.model.Invitation;
+import uk.gov.companieshouse.api.accounts.associations.model.Links;
 import uk.gov.companieshouse.api.accounts.user.model.User;
+
+import java.util.Objects;
+import java.util.Optional;
 
 @Component
 public class MapperUtil {
@@ -66,8 +65,6 @@ public class MapperUtil {
     }
 
     public AssociationsList enrichWithMetadata(final Page<Association> page, final String endpointUrl) {
-
-
         AssociationsList list = new AssociationsList();
         final var pageIndex = page.getNumber();
         final var itemsPerPage = page.getSize();
@@ -75,9 +72,9 @@ public class MapperUtil {
         final var totalResults = page.getTotalElements();
         final var isLastPage = page.isLast();
         final var associations = "/associations";
-        final var self = totalResults == 0 || pageIndex >= totalResults ? "" : String.format("%s%s?page_index=%d&items_per_page=%d", associations, endpointUrl, pageIndex, itemsPerPage);
+        final var self = String.format("%s%s?page_index=%d&items_per_page=%d", associations, endpointUrl, pageIndex, itemsPerPage);
         final var next = isLastPage ? "" : String.format("%s%s?page_index=%d&items_per_page=%d", associations, endpointUrl, pageIndex + 1, itemsPerPage);
-        final var links = new AssociationsListLinks().self(self).next(next);
+        final var links = new Links().self(self).next(next);
 
         list.setItems(page.getContent());
         list.links(links)

--- a/src/test/java/uk/gov/companieshouse/accounts/association/controller/AssociationsListForCompanyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/controller/AssociationsListForCompanyControllerTest.java
@@ -1,15 +1,7 @@
 package uk.gov.companieshouse.accounts.association.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -35,9 +27,18 @@ import uk.gov.companieshouse.api.accounts.associations.model.Association.Approva
 import uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum;
 import uk.gov.companieshouse.api.accounts.associations.model.AssociationLinks;
 import uk.gov.companieshouse.api.accounts.associations.model.AssociationsList;
-import uk.gov.companieshouse.api.accounts.associations.model.AssociationsListLinks;
 import uk.gov.companieshouse.api.accounts.associations.model.Invitation;
+import uk.gov.companieshouse.api.accounts.associations.model.Links;
 import uk.gov.companieshouse.api.company.CompanyDetails;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @WebMvcTest(AssociationsListForCompanyController.class)
@@ -155,7 +156,7 @@ import uk.gov.companieshouse.api.company.CompanyDetails;
         expectedAssociationsList.setTotalPages( 1 );
         expectedAssociationsList.setPageNumber( 0 );
         expectedAssociationsList.setItemsPerPage( 15 );
-        expectedAssociationsList.setLinks( new AssociationsListLinks().self(String.format("%s/associations", internalApiUrl)).next("") );
+        expectedAssociationsList.setLinks( new Links().self(String.format("%s/associations", internalApiUrl)).next("") );
         expectedAssociationsList.setItems(List.of( associationOne ));
         Mockito.doReturn(expectedAssociationsList).when(associationsService).fetchAssociatedUsers( any(), any(), eq( false ), eq( 15 ), eq( 0 ) );
 
@@ -178,7 +179,7 @@ import uk.gov.companieshouse.api.company.CompanyDetails;
         expectedAssociationsList.setTotalPages( 1 );
         expectedAssociationsList.setPageNumber( 0 );
         expectedAssociationsList.setItemsPerPage( 15 );
-        expectedAssociationsList.setLinks( new AssociationsListLinks().self(String.format("%s/associations", internalApiUrl)).next("") );
+        expectedAssociationsList.setLinks( new Links().self(String.format("%s/associations", internalApiUrl)).next("") );
         expectedAssociationsList.setItems(List.of( associationOne ));
         Mockito.doReturn(expectedAssociationsList).when(associationsService).fetchAssociatedUsers( any(), any(), eq( false ), eq( 15 ), eq( 0 ) );
 
@@ -200,7 +201,7 @@ import uk.gov.companieshouse.api.company.CompanyDetails;
         expectedAssociationsList.setTotalPages( 1 );
         expectedAssociationsList.setPageNumber( 0 );
         expectedAssociationsList.setItemsPerPage( 15 );
-        expectedAssociationsList.setLinks( new AssociationsListLinks().self(String.format("%s/associations", internalApiUrl)).next("") );
+        expectedAssociationsList.setLinks( new Links().self(String.format("%s/associations", internalApiUrl)).next("") );
         expectedAssociationsList.setItems(List.of( associationOne, associationTwo ));
         Mockito.doReturn(expectedAssociationsList).when(associationsService).fetchAssociatedUsers( any(), any(), eq( true ), eq( 15 ), eq( 0 ) );
 
@@ -222,7 +223,7 @@ import uk.gov.companieshouse.api.company.CompanyDetails;
         expectedAssociationsList.setTotalPages( 2 );
         expectedAssociationsList.setPageNumber( 1 );
         expectedAssociationsList.setItemsPerPage( 1 );
-        expectedAssociationsList.setLinks( new AssociationsListLinks().self(String.format("%s/associations", internalApiUrl)).next("") );
+        expectedAssociationsList.setLinks( new Links().self(String.format("%s/associations", internalApiUrl)).next("") );
         expectedAssociationsList.setItems(List.of( associationTwo ));
         Mockito.doReturn(expectedAssociationsList).when(associationsService).fetchAssociatedUsers( any(), any(), eq( true ), eq( 1 ), eq( 1 ) );
 
@@ -283,7 +284,7 @@ import uk.gov.companieshouse.api.company.CompanyDetails;
         expectedAssociationsList.setTotalPages( 1 );
         expectedAssociationsList.setPageNumber( 0 );
         expectedAssociationsList.setItemsPerPage( 2 );
-        expectedAssociationsList.setLinks( new AssociationsListLinks().self(String.format("%s/associations", internalApiUrl)).next("") );
+        expectedAssociationsList.setLinks( new Links().self(String.format("%s/associations", internalApiUrl)).next("") );
         expectedAssociationsList.setItems(List.of( associationOne, associationTwo ));
         Mockito.doReturn(expectedAssociationsList).when(associationsService).fetchAssociatedUsers( any(), any(), eq( true ), eq( 2 ), eq( 0 ) );
 

--- a/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociationsTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociationsTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.companieshouse.accounts.association.exceptions.BadRequestRuntimeException;
 import uk.gov.companieshouse.accounts.association.exceptions.InternalServerErrorRuntimeException;
 import uk.gov.companieshouse.accounts.association.exceptions.NotFoundRuntimeException;
@@ -26,9 +27,15 @@ import uk.gov.companieshouse.accounts.association.service.CompanyService;
 import uk.gov.companieshouse.accounts.association.service.EmailService;
 import uk.gov.companieshouse.accounts.association.service.UsersService;
 import uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil;
-import uk.gov.companieshouse.api.accounts.associations.model.*;
+import uk.gov.companieshouse.api.accounts.associations.model.Association;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.ApprovalRouteEnum;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum;
+import uk.gov.companieshouse.api.accounts.associations.model.AssociationLinks;
+import uk.gov.companieshouse.api.accounts.associations.model.AssociationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.Invitation;
+import uk.gov.companieshouse.api.accounts.associations.model.InvitationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.Links;
+import uk.gov.companieshouse.api.accounts.associations.model.ResponseBodyPost;
 import uk.gov.companieshouse.api.accounts.user.model.User;
 import uk.gov.companieshouse.api.accounts.user.model.UsersList;
 import uk.gov.companieshouse.api.company.CompanyDetails;
@@ -41,10 +48,16 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserCompanyAssociations.class)
@@ -313,7 +326,7 @@ class UserCompanyAssociationsTest {
 
         final var expectedAssociationsList = new AssociationsList();
         expectedAssociationsList.setItems(List.of(associationOne));
-        expectedAssociationsList.setLinks(new AssociationsListLinks().self("/associations?page_index=0&items_per_page=15").next(""));
+        expectedAssociationsList.setLinks(new Links().self("/associations?page_index=0&items_per_page=15").next(""));
         expectedAssociationsList.setItemsPerPage(15);
         expectedAssociationsList.setPageNumber(0);
         expectedAssociationsList.setTotalPages(1);
@@ -354,7 +367,7 @@ class UserCompanyAssociationsTest {
     void fetchAssociationsByWithOneStatusAppliesStatusFilterCorrectly() throws Exception {
         final var expectedAssociationsList = new AssociationsList();
         expectedAssociationsList.setItems(List.of(associationTwo));
-        expectedAssociationsList.setLinks(new AssociationsListLinks().self("/associations?page_index=0&items_per_page=15").next(""));
+        expectedAssociationsList.setLinks(new Links().self("/associations?page_index=0&items_per_page=15").next(""));
         expectedAssociationsList.setItemsPerPage(15);
         expectedAssociationsList.setPageNumber(0);
         expectedAssociationsList.setTotalPages(1);
@@ -395,7 +408,7 @@ class UserCompanyAssociationsTest {
     void fetchAssociationsByWithMultipleStatusesAppliesStatusFilterCorrectly() throws Exception {
         final var expectedAssociationsList = new AssociationsList();
         expectedAssociationsList.setItems(List.of(associationOne, associationTwo));
-        expectedAssociationsList.setLinks(new AssociationsListLinks().self("/associations?page_index=0&items_per_page=15").next(""));
+        expectedAssociationsList.setLinks(new Links().self("/associations?page_index=0&items_per_page=15").next(""));
         expectedAssociationsList.setItemsPerPage(15);
         expectedAssociationsList.setPageNumber(0);
         expectedAssociationsList.setTotalPages(1);
@@ -436,7 +449,7 @@ class UserCompanyAssociationsTest {
     void fetchAssociationsByImplementsPaginationCorrectly() throws Exception {
         final var expectedAssociationsList = new AssociationsList();
         expectedAssociationsList.setItems(List.of(associationTwo));
-        expectedAssociationsList.setLinks(new AssociationsListLinks().self("/associations?page_index=1&items_per_page=1").next(""));
+        expectedAssociationsList.setLinks(new Links().self("/associations?page_index=1&items_per_page=1").next(""));
         expectedAssociationsList.setItemsPerPage(1);
         expectedAssociationsList.setPageNumber(1);
         expectedAssociationsList.setTotalPages(2);
@@ -477,7 +490,7 @@ class UserCompanyAssociationsTest {
     void fetchAssociationsByFiltersBasedOnCompanyNumberCorrectly() throws Exception {
         final var expectedAssociationsList = new AssociationsList();
         expectedAssociationsList.setItems(List.of(associationTwo));
-        expectedAssociationsList.setLinks(new AssociationsListLinks().self("/associations?page_index=0&items_per_page=15").next(""));
+        expectedAssociationsList.setLinks(new Links().self("/associations?page_index=0&items_per_page=15").next(""));
         expectedAssociationsList.setItemsPerPage(15);
         expectedAssociationsList.setPageNumber(0);
         expectedAssociationsList.setTotalPages(1);
@@ -527,7 +540,7 @@ class UserCompanyAssociationsTest {
     void fetchAssociationsByDoesMappingCorrectly() throws Exception {
         final var expectedAssociationsList = new AssociationsList();
         expectedAssociationsList.setItems(List.of(associationOne));
-        expectedAssociationsList.setLinks(new AssociationsListLinks().self("/associations?page_index=0&items_per_page=15").next(""));
+        expectedAssociationsList.setLinks(new Links().self("/associations?page_index=0&items_per_page=15").next(""));
         expectedAssociationsList.setItemsPerPage(15);
         expectedAssociationsList.setPageNumber(0);
         expectedAssociationsList.setTotalPages(1);
@@ -1692,7 +1705,7 @@ class UserCompanyAssociationsTest {
         invitationsList.items(List.of(invitation1, invitation2));
         AssociationDao associationDao = new AssociationDao();
         Mockito.doReturn(Optional.of(associationDao)).when(associationsService).findAssociationDaoById("18");
-        Mockito.doReturn(invitationsList).when(associationsService).fetchInvitations(associationDao);
+        Mockito.doReturn(invitationsList).when(associationsService).fetchInvitations(associationDao, 0, 15);
 
         final var response = mockMvc.perform(get("/associations/{id}/invitations", "18")
                         .header("X-Request-Id", "theId123")
@@ -1810,6 +1823,110 @@ class UserCompanyAssociationsTest {
                 .getResponse();
 
         Mockito.verify( associationsService ).fetchActiveInvitations( eq( "99999" ), eq( 0 ), eq( 15 ) );
+    }
+
+    @Test
+    void fetchActiveInvitationsForUserWithPaginationAndVerifyResponse() throws Exception {
+        Invitation invitation1 = new Invitation();
+        invitation1.setInvitedBy("user1@example.com");
+        invitation1.setInvitedAt(LocalDateTime.now().toString());
+
+        Invitation invitation2 = new Invitation();
+        invitation2.setInvitedBy("user2@example.com");
+        invitation2.setInvitedAt(LocalDateTime.now().toString());
+
+        List<Invitation> mockInvitations = List.of(invitation1, invitation2);
+        InvitationsList mockInvitationsList = new InvitationsList();
+        mockInvitationsList.setItemsPerPage(1);
+        mockInvitationsList.setPageNumber(1);
+        mockInvitationsList.setTotalResults(2);
+        mockInvitationsList.setTotalPages(2);
+        mockInvitationsList.setItems(mockInvitations);
+
+        Links mockLinks = new Links();
+        mockLinks.setSelf("/associations/invitations?page_index=1&items_per_page=1");
+        mockLinks.setNext("/associations/invitations?page_index=2&items_per_page=1");
+        mockInvitationsList.setLinks(mockLinks);
+
+        when(associationsService.fetchActiveInvitations(eq("99999"), eq(1), eq(1)))
+                .thenReturn(mockInvitationsList);
+
+        MvcResult result = mockMvc.perform(get("/associations/invitations?page_index=1&items_per_page=1")
+                        .header("X-Request-Id", "theId123")
+                        .header("Eric-identity", "99999")
+                        .header("ERIC-Identity-Type", "oauth2")
+                        .header("ERIC-Authorised-Key-Roles", "*"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseContent = result.getResponse().getContentAsString();
+
+        InvitationsList invitationsList = new ObjectMapper().readValue(responseContent, InvitationsList.class);
+
+        assertNotNull(invitationsList);
+        assertEquals(1, invitationsList.getItemsPerPage().intValue());
+        assertEquals(1, invitationsList.getPageNumber().intValue());
+        assertEquals(2, invitationsList.getTotalResults().intValue());
+        assertEquals(2, invitationsList.getTotalPages().intValue());
+        assertNotNull(invitationsList.getLinks());
+        assertEquals("/associations/invitations?page_index=1&items_per_page=1", invitationsList.getLinks().getSelf());
+        assertEquals("/associations/invitations?page_index=2&items_per_page=1", invitationsList.getLinks().getNext());
+
+        Mockito.verify(associationsService).fetchActiveInvitations(eq("99999"), eq(1), eq(1));
+    }
+
+    @Test
+    void getInvitationsForAssociationWithPaginationAndVerifyResponse() throws Exception {
+        Invitation invitation1 = new Invitation();
+        invitation1.setInvitedBy("user1@example.com");
+        invitation1.setInvitedAt(LocalDateTime.now().toString());
+
+        Invitation invitation2 = new Invitation();
+        invitation2.setInvitedBy("user2@example.com");
+        invitation2.setInvitedAt(LocalDateTime.now().toString());
+
+        List<Invitation> mockInvitations = List.of(invitation1, invitation2);
+        InvitationsList mockInvitationsList = new InvitationsList();
+        mockInvitationsList.setItemsPerPage(1);
+        mockInvitationsList.setPageNumber(1);
+        mockInvitationsList.setTotalResults(2);
+        mockInvitationsList.setTotalPages(2);
+        mockInvitationsList.setItems(mockInvitations);
+
+        Links mockLinks = new Links();
+        mockLinks.setSelf("/associations/12345/invitations?page_index=1&items_per_page=1");
+        mockLinks.setNext("/associations/12345/invitations?page_index=2&items_per_page=1");
+        mockInvitationsList.setLinks(mockLinks);
+
+        AssociationDao mockAssociationDao = new AssociationDao();
+        when(associationsService.findAssociationDaoById(eq("12345")))
+                .thenReturn(Optional.of(mockAssociationDao));
+        when(associationsService.fetchInvitations(eq(mockAssociationDao), eq(1), eq(1)))
+                .thenReturn(mockInvitationsList);
+
+        MvcResult result = mockMvc.perform(get("/associations/12345/invitations?page_index=1&items_per_page=1")
+                        .header("X-Request-Id", "theId123")
+                        .header("Eric-identity", "99999")
+                        .header("ERIC-Identity-Type", "oauth2")
+                        .header("ERIC-Authorised-Key-Roles", "*"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseContent = result.getResponse().getContentAsString();
+
+        InvitationsList invitationsList = new ObjectMapper().readValue(responseContent, InvitationsList.class);
+
+        assertNotNull(invitationsList);
+        assertEquals(1, invitationsList.getItemsPerPage().intValue());
+        assertEquals(1, invitationsList.getPageNumber().intValue());
+        assertEquals(2, invitationsList.getTotalResults().intValue());
+        assertEquals(2, invitationsList.getTotalPages().intValue());
+        assertNotNull(invitationsList.getLinks());
+        assertEquals("/associations/12345/invitations?page_index=1&items_per_page=1", invitationsList.getLinks().getSelf());
+        assertEquals("/associations/12345/invitations?page_index=2&items_per_page=1", invitationsList.getLinks().getNext());
+
+        Mockito.verify(associationsService).findAssociationDaoById(eq("12345"));
+        Mockito.verify(associationsService).fetchInvitations(eq(mockAssociationDao), eq(1), eq(1));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociationsTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociationsTest.java
@@ -284,6 +284,26 @@ class UserCompanyAssociationsTest {
     }
 
     @Test
+    void getInvitationsForAssociationWithUnacceptablePageIndexReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/associations/12345/invitations?page_index=-1&items_per_page=1")
+                        .header("X-Request-Id", "theId123")
+                        .header("Eric-identity", "99999")
+                        .header("ERIC-Identity-Type", "oauth2")
+                        .header("ERIC-Authorised-Key-Roles", "*"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getInvitationsForAssociationWithUnacceptableItemsPerPageReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/associations/12345/invitations?page_index=0&items_per_page=-1")
+                        .header("X-Request-Id", "theId123")
+                        .header("Eric-identity", "99999")
+                        .header("ERIC-Identity-Type", "oauth2")
+                        .header("ERIC-Authorised-Key-Roles", "*"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void fetchAssociationsByWithNonexistentCompanyReturnsNotFound() throws Exception {
         final var user = new User().userId("8888").email("mr.blobby@nightmare.com").displayName("Mr Blobby");
         Mockito.doReturn(user).when(usersService).fetchUserDetails("8888");


### PR DESCRIPTION
__Short description outlining key changes/additions__

Added pagination for invitations to the UserCompanyAssociations service. Updated methods to include `pageIndex` and `itemsPerPage` parameters, refactored service methods, and adjusted test cases accordingly.

Sonar - https://code-analysis.platform.aws.chdev.org/dashboard?id=uk.gov.companieshouse%3Aaccounts-association-api&pullRequest=105

__JIRA Ticket Number__

https://companieshouse.atlassian.net/browse/IDVA6-1106

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__