### PR TITLE
IDVA6-1211: Determine isActive if before invitation date + 7 days

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/association/mapper/InvitationsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/mapper/InvitationsMapper.java
@@ -27,10 +27,14 @@ public abstract class InvitationsMapper {
 
     public Stream<Invitation> daoToDto( AssociationDao association ){
         return association.getInvitations()
-                          .stream()
-                          .map( this::daoToDto )
-                          .map( invitation -> invitation.associationId( association.getId() ) )
-                          .map( invitation -> invitation.isActive( association.getApprovalExpiryAt().isAfter( LocalDateTime.now() ) ) );
+                .stream()
+                .map(invitationDao -> {
+                    boolean isActive = LocalDateTime.now().isBefore(invitationDao.getExpiredAt());
+                    Invitation invitation = daoToDto(invitationDao);
+                    invitation.setAssociationId(association.getId());
+                    invitation.setIsActive(isActive);
+                    return invitation;
+                });
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/accounts/association/models/InvitationDao.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/models/InvitationDao.java
@@ -4,6 +4,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
 
+import static uk.gov.companieshouse.accounts.association.service.AssociationsService.DAYS_SINCE_INVITE_TILL_EXPIRES;
+
 public class InvitationDao {
     @Field("invited_by")
     private String invitedBy;
@@ -24,6 +26,10 @@ public class InvitationDao {
 
     public void setInvitedAt(LocalDateTime invitedAt) {
         this.invitedAt = invitedAt;
+    }
+
+    public LocalDateTime getExpiredAt() {
+        return invitedAt.plusDays(DAYS_SINCE_INVITE_TILL_EXPIRES);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/accounts/association/models/InvitationDao.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/models/InvitationDao.java
@@ -4,7 +4,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
 
-import static uk.gov.companieshouse.accounts.association.service.AssociationsService.DAYS_SINCE_INVITE_TILL_EXPIRES;
+import static uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil.DAYS_SINCE_INVITE_TILL_EXPIRES;
 
 public class InvitationDao {
     @Field("invited_by")

--- a/src/main/java/uk/gov/companieshouse/accounts/association/service/AssociationsService.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/service/AssociationsService.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.companieshouse.GenerateEtagUtil.generateEtag;
+import static uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil.DAYS_SINCE_INVITE_TILL_EXPIRES;
 
 @Service
 public class AssociationsService {
@@ -54,9 +55,6 @@ public class AssociationsService {
     private final InvitationsMapper invitationMapper;
 
     private static final Logger LOG = LoggerFactory.getLogger(StaticPropertyUtil.APPLICATION_NAMESPACE);
-
-    public static final int DAYS_SINCE_INVITE_TILL_EXPIRES = 7;
-
 
     @Autowired
     public AssociationsService(AssociationsRepository associationsRepository,

--- a/src/main/java/uk/gov/companieshouse/accounts/association/service/AssociationsService.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/service/AssociationsService.java
@@ -17,23 +17,32 @@ import uk.gov.companieshouse.accounts.association.models.AssociationDao;
 import uk.gov.companieshouse.accounts.association.models.InvitationDao;
 import uk.gov.companieshouse.accounts.association.repositories.AssociationsRepository;
 import uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil;
-import uk.gov.companieshouse.api.accounts.associations.model.*;
+import uk.gov.companieshouse.api.accounts.associations.model.Association;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.ApprovalRouteEnum;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum;
+import uk.gov.companieshouse.api.accounts.associations.model.AssociationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.Invitation;
+import uk.gov.companieshouse.api.accounts.associations.model.InvitationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.Links;
 import uk.gov.companieshouse.api.accounts.user.model.User;
 import uk.gov.companieshouse.api.company.CompanyDetails;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static uk.gov.companieshouse.GenerateEtagUtil.generateEtag;
 
 @Service
 public class AssociationsService {
-
 
     private final AssociationsRepository associationsRepository;
     private final AssociationsListUserMapper associationsListUserMapper;
@@ -45,6 +54,9 @@ public class AssociationsService {
     private final InvitationsMapper invitationMapper;
 
     private static final Logger LOG = LoggerFactory.getLogger(StaticPropertyUtil.APPLICATION_NAMESPACE);
+
+    public static final int DAYS_SINCE_INVITE_TILL_EXPIRES = 7;
+
 
     @Autowired
     public AssociationsService(AssociationsRepository associationsRepository,
@@ -176,7 +188,7 @@ public class AssociationsService {
         invitationDao.setInvitedAt(LocalDateTime.now());
         invitationDao.setInvitedBy(invitedByUserId);
         association.setStatus(StatusEnum.AWAITING_APPROVAL.getValue());
-        association.setApprovalExpiryAt(LocalDateTime.now().plusDays(7));
+        association.setApprovalExpiryAt(LocalDateTime.now().plusDays(DAYS_SINCE_INVITE_TILL_EXPIRES));
         association.getInvitations().add(invitationDao);
     }
 

--- a/src/main/java/uk/gov/companieshouse/accounts/association/utils/StaticPropertyUtil.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/utils/StaticPropertyUtil.java
@@ -7,9 +7,13 @@ import org.springframework.stereotype.Component;
 public class StaticPropertyUtil {
 
     public static String APPLICATION_NAMESPACE;
+    public static int DAYS_SINCE_INVITE_TILL_EXPIRES = 7;
 
-    public StaticPropertyUtil(@Value("${spring.application.name}") String applicationNameSpace ) {
+    public StaticPropertyUtil(
+            @Value("${spring.application.name}") String applicationNameSpace,
+            @Value("${invite.expiry.days:7}") int daysSinceInviteTillExpires
+    ) {
         StaticPropertyUtil.APPLICATION_NAMESPACE = applicationNameSpace;
+        StaticPropertyUtil.DAYS_SINCE_INVITE_TILL_EXPIRES = daysSinceInviteTillExpires;
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/accounts/association/integration/UserCompanyAssociationsTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/integration/UserCompanyAssociationsTest.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException.Builder;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
@@ -26,16 +30,24 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.gov.companieshouse.accounts.association.models.AssociationDao;
 import uk.gov.companieshouse.accounts.association.models.InvitationDao;
-import uk.gov.companieshouse.accounts.association.models.email.data.*;
+import uk.gov.companieshouse.accounts.association.models.email.data.AuthCodeConfirmationEmailData;
+import uk.gov.companieshouse.accounts.association.models.email.data.AuthorisationRemovedEmailData;
+import uk.gov.companieshouse.accounts.association.models.email.data.InvitationAcceptedEmailData;
+import uk.gov.companieshouse.accounts.association.models.email.data.InvitationEmailData;
+import uk.gov.companieshouse.accounts.association.models.email.data.InviteEmailData;
 import uk.gov.companieshouse.accounts.association.repositories.AssociationsRepository;
 import uk.gov.companieshouse.accounts.association.rest.AccountsUserEndpoint;
 import uk.gov.companieshouse.accounts.association.rest.CompanyProfileEndpoint;
 import uk.gov.companieshouse.accounts.association.service.EmailService;
 import uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil;
 import uk.gov.companieshouse.api.InternalApiClient;
-import uk.gov.companieshouse.api.accounts.associations.model.*;
+import uk.gov.companieshouse.api.accounts.associations.model.Association;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.ApprovalRouteEnum;
 import uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum;
+import uk.gov.companieshouse.api.accounts.associations.model.AssociationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.InvitationsList;
+import uk.gov.companieshouse.api.accounts.associations.model.RequestBodyPut;
+import uk.gov.companieshouse.api.accounts.associations.model.ResponseBodyPost;
 import uk.gov.companieshouse.api.accounts.user.model.User;
 import uk.gov.companieshouse.api.accounts.user.model.UsersList;
 import uk.gov.companieshouse.api.company.CompanyDetails;
@@ -55,12 +67,20 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.companieshouse.accounts.association.utils.MessageType.*;
+import static uk.gov.companieshouse.accounts.association.utils.MessageType.AUTHORISATION_REMOVED_MESSAGE_TYPE;
+import static uk.gov.companieshouse.accounts.association.utils.MessageType.AUTH_CODE_CONFIRMATION_MESSAGE_TYPE;
+import static uk.gov.companieshouse.accounts.association.utils.MessageType.INVITATION_ACCEPTED_MESSAGE_TYPE;
+import static uk.gov.companieshouse.accounts.association.utils.MessageType.INVITATION_MESSAGE_TYPE;
+import static uk.gov.companieshouse.accounts.association.utils.MessageType.INVITE_MESSAGE_TYPE;
 
 @AutoConfigureMockMvc
 @SpringBootTest
@@ -669,7 +689,7 @@ public class UserCompanyAssociationsTest {
 
         final var invitationFortyEightNewest = new InvitationDao();
         invitationFortyEightNewest.setInvitedBy("444");
-        invitationFortyEightNewest.setInvitedAt( now.minusDays(1) );
+        invitationFortyEightNewest.setInvitedAt( now.plusDays(8) );
 
         final var associationFortyEight = new AssociationDao();
         associationFortyEight.setCompanyNumber("444444P");


### PR DESCRIPTION
__Short description outlining key changes/additions__

Added functionality to correctly determine the isActive status for each invitation based on their individual expiry dates.

__JIRA Ticket Number__

https://companieshouse.atlassian.net/browse/IDVA6-1211

__Sonar__

https://code-analysis.platform.aws.chdev.org/dashboard?id=uk.gov.companieshouse%3Aaccounts-association-api&pullRequest=117

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__