### PR TITLE
Made fetchActiveInvitations more flexible, so that it can fetch assoc…

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociations.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociations.java
@@ -111,7 +111,9 @@ public class UserCompanyAssociations implements UserCompanyAssociationsInterface
             throw new BadRequestRuntimeException(PLEASE_CHECK_THE_REQUEST_AND_TRY_AGAIN);
         }
 
-        final var invitations = associationsService.fetchActiveInvitations( ericIdentity, pageIndex, itemsPerPage );
+        final var user = UserContext.getLoggedUser();
+
+        final var invitations = associationsService.fetchActiveInvitations( user, pageIndex, itemsPerPage );
         LOG.debugContext( xRequestId, String.format( "Successfully retrieved active invitations for user %s", ericIdentity ), null );
 
        return new ResponseEntity<>( invitations, HttpStatus.OK );

--- a/src/main/java/uk/gov/companieshouse/accounts/association/repositories/AssociationsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/repositories/AssociationsRepository.java
@@ -43,7 +43,7 @@ public interface AssociationsRepository extends MongoRepository<AssociationDao, 
     @Query( " { '_id': ?0 } " )
     int updateAssociation( String associationId, Update update );
 
-    @Query( "{ 'user_id': ?0, 'status': 'awaiting-approval', 'approval_expiry_at': { $gt: ?1 } }" )
-    Stream<AssociationDao> fetchAssociationsWithActiveInvitations( final String userId, final LocalDateTime now );
+    @Query( "{ '$or': [ { 'user_id': { '$ne': null, '$eq': ?0 } }, { 'user_email': { '$ne': null, '$eq': ?1 } } ], 'status': 'awaiting-approval', 'approval_expiry_at': { $gt: ?2 } }" )
+    Stream<AssociationDao> fetchAssociationsWithActiveInvitations( final String userId, final String userEmail, final LocalDateTime now );
 
 }

--- a/src/main/java/uk/gov/companieshouse/accounts/association/service/AssociationsService.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/service/AssociationsService.java
@@ -219,8 +219,8 @@ public class AssociationsService {
     }
 
     @Transactional(readOnly = true)
-    public InvitationsList fetchActiveInvitations(final String userId, final int pageIndex, final int itemsPerPage) {
-        List<Invitation> allInvitations = associationsRepository.fetchAssociationsWithActiveInvitations(userId, LocalDateTime.now())
+    public InvitationsList fetchActiveInvitations(final User user, final int pageIndex, final int itemsPerPage) {
+        List<Invitation> allInvitations = associationsRepository.fetchAssociationsWithActiveInvitations(user.getUserId(), user.getEmail(), LocalDateTime.now())
                 .map(this::filterForMostRecentInvitation)
                 .sorted(Comparator.comparing(AssociationDao::getApprovalExpiryAt).reversed())
                 .flatMap(invitationMapper::daoToDto)

--- a/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociationsTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociationsTest.java
@@ -1947,7 +1947,9 @@ class UserCompanyAssociationsTest {
 
     @Test
     void fetchActiveInvitationsForUserRetrievesActiveInvitationsInCorrectOrderAndPaginatesCorrectly() throws Exception {
-            mockMvc.perform( get( "/associations/invitations?page_index=1&items_per_page=1" )
+        when(usersService.fetchUserDetails("99999")).thenReturn(new User().userId("99999"));
+
+        mockMvc.perform( get( "/associations/invitations?page_index=1&items_per_page=1" )
                             .header("X-Request-Id", "theId123")
                             .header("Eric-identity", "99999")
                             .header("ERIC-Identity-Type", "oauth2")
@@ -1956,11 +1958,13 @@ class UserCompanyAssociationsTest {
                     .andReturn()
                     .getResponse();
 
-        Mockito.verify( associationsService ).fetchActiveInvitations( eq( "99999" ), eq( 1 ), eq( 1 ) );
+        Mockito.verify( associationsService ).fetchActiveInvitations( argThat( user -> user.getUserId().equals("99999") ), eq( 1 ), eq( 1 ) );
     }
 
     @Test
     void fetchActiveInvitationsForUserWithoutPageIndexAndItemsPerPageUsesDefaults() throws Exception {
+        when(usersService.fetchUserDetails("99999")).thenReturn(new User().userId("99999"));
+
         mockMvc.perform( get( "/associations/invitations" )
                         .header("X-Request-Id", "theId123")
                         .header("Eric-identity", "99999")
@@ -1970,11 +1974,13 @@ class UserCompanyAssociationsTest {
                 .andReturn()
                 .getResponse();
 
-        Mockito.verify( associationsService ).fetchActiveInvitations( eq( "99999" ), eq( 0 ), eq( 15 ) );
+        Mockito.verify( associationsService ).fetchActiveInvitations( argThat( user -> user.getUserId().equals("99999") ), eq( 0 ), eq( 15 ) );
     }
 
     @Test
     void fetchActiveInvitationsForUserWithPaginationAndVerifyResponse() throws Exception {
+        when(usersService.fetchUserDetails("99999")).thenReturn(new User().userId("99999"));
+
         Invitation invitation1 = new Invitation();
         invitation1.setInvitedBy("user1@example.com");
         invitation1.setInvitedAt(LocalDateTime.now().toString());
@@ -1996,7 +2002,7 @@ class UserCompanyAssociationsTest {
         mockLinks.setNext("/associations/invitations?page_index=2&items_per_page=1");
         mockInvitationsList.setLinks(mockLinks);
 
-        when(associationsService.fetchActiveInvitations(eq("99999"), eq(1), eq(1)))
+        when(associationsService.fetchActiveInvitations(argThat( user -> user.getUserId().equals("99999") ), eq(1), eq(1)))
                 .thenReturn(mockInvitationsList);
 
         MvcResult result = mockMvc.perform(get("/associations/invitations?page_index=1&items_per_page=1")
@@ -2020,7 +2026,7 @@ class UserCompanyAssociationsTest {
         assertEquals("/associations/invitations?page_index=1&items_per_page=1", invitationsList.getLinks().getSelf());
         assertEquals("/associations/invitations?page_index=2&items_per_page=1", invitationsList.getLinks().getNext());
 
-        Mockito.verify(associationsService).fetchActiveInvitations(eq("99999"), eq(1), eq(1));
+        Mockito.verify(associationsService).fetchActiveInvitations(argThat( user -> user.getUserId().equals("99999") ), eq(1), eq(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/accounts/association/integration/AssociationsRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/integration/AssociationsRepositoryTest.java
@@ -909,16 +909,29 @@ class AssociationsRepositoryTest {
     }
 
     @Test
-    void fetchAssociationsWithActiveInvitationsWithNullOrMalformedOrNonExistentUserIdOrNullTimestampReturnsEmptyStream(){
-        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( null, LocalDateTime.now() ).toList().isEmpty() );
-        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( "$$$", LocalDateTime.now() ).toList().isEmpty() );
-        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( "9191", LocalDateTime.now() ).toList().isEmpty() );
-        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( "99999", null ).toList().isEmpty() );
+    void fetchAssociationsWithActiveInvitationsWithNullOrMalformedOrNonExistentUserIdOrEmailOrNullTimestampReturnsEmptyStream(){
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( null, null, LocalDateTime.now() ).toList().isEmpty() );
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( "$$$", null,LocalDateTime.now() ).toList().isEmpty() );
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( "9191", null,LocalDateTime.now() ).toList().isEmpty() );
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( "99999", null,null ).toList().isEmpty() );
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( null, "$$$",LocalDateTime.now() ).toList().isEmpty() );
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( null, "ronald@mcdonalds.com",LocalDateTime.now() ).toList().isEmpty() );
+        Assertions.assertTrue( associationsRepository.fetchAssociationsWithActiveInvitations( null, "ronald@mcdonalds.com",null ).toList().isEmpty() );
     }
 
     @Test
-    void fetchAssociationsWithActiveInvitationsAppliesFiltersCorrectly(){
-        final var associationIds = associationsRepository.fetchAssociationsWithActiveInvitations( "99999", LocalDateTime.now() )
+    void fetchAssociationsWithActiveInvitationsBasedOnUserIdAppliesFiltersCorrectly(){
+        final var associationIds = associationsRepository.fetchAssociationsWithActiveInvitations( "99999", null, LocalDateTime.now() )
+                .map( AssociationDao::getId )
+                .toList();
+
+        Assertions.assertEquals( 2, associationIds.size() );
+        Assertions.assertTrue( associationIds.containsAll( List.of( "18", "19" ) ) );
+    }
+    
+    @Test
+    void fetchAssociationsWithActiveInvitationsBasedOnUserEmailAppliesFiltersCorrectly(){
+        final var associationIds = associationsRepository.fetchAssociationsWithActiveInvitations( null, "scrooge.mcduck1@disney.land", LocalDateTime.now() )
                 .map( AssociationDao::getId )
                 .toList();
 

--- a/src/test/java/uk/gov/companieshouse/accounts/association/integration/AssociationsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/integration/AssociationsServiceTest.java
@@ -1027,9 +1027,9 @@ public class AssociationsServiceTest {
 
     @Test
     void fetchActiveInvitationsWithNullOrMalformedOrNonexistentUserIdReturnsEmptyList(){
-        Assertions.assertEquals( Collections.emptyList(), associationsService.fetchActiveInvitations( null, 0, 1 ).getItems() );
-        Assertions.assertEquals( Collections.emptyList(), associationsService.fetchActiveInvitations( "$$$", 0, 1 ).getItems() );
-        Assertions.assertEquals( Collections.emptyList(), associationsService.fetchActiveInvitations( "9191", 0, 1 ).getItems() );
+        Assertions.assertEquals( Collections.emptyList(), associationsService.fetchActiveInvitations( new User(), 0, 1 ).getItems() );
+        Assertions.assertEquals( Collections.emptyList(), associationsService.fetchActiveInvitations( new User().userId("$$$"), 0, 1 ).getItems() );
+        Assertions.assertEquals( Collections.emptyList(), associationsService.fetchActiveInvitations( new User().userId("9191"), 0, 1 ).getItems() );
     }
 
     ArgumentMatcher<AssociationDao> associationIdMatches( String associationId ){
@@ -1078,7 +1078,7 @@ public class AssociationsServiceTest {
         Mockito.doReturn( Stream.of( invitationThirtyFive ) ).when( invitationsMapper ).daoToDto( argThat( associationIdMatches( "34" ) ) );
         Mockito.doReturn( Stream.of( invitationThirtyFive ) ).when( invitationsMapper ).daoToDto( argThat( associationIdMatches( "35" ) ) );
 
-        associationsService.fetchActiveInvitations( "99999", 1, 1 );
+        associationsService.fetchActiveInvitations( new User().userId("99999"), 1, 1 );
 
         Mockito.verify(invitationsMapper).daoToDto(argThat(associationDaoMatches("35", now.plusDays(8), "444", now.minusDays(1))));
     }

--- a/src/test/java/uk/gov/companieshouse/accounts/association/service/AssociationsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/service/AssociationsServiceTest.java
@@ -1145,7 +1145,7 @@ class AssociationsServiceTest {
     @ParameterizedTest
     @MethodSource("userIdsProvider")
     void fetchActiveInvitationsWithNullOrMalformedOrNonexistentUserIdReturnsEmptyList(String userId) {
-        InvitationsList invitations = associationsService.fetchActiveInvitations(userId, 0, 1);
+        InvitationsList invitations = associationsService.fetchActiveInvitations(new User().userId(userId), 0, 1);
 
         assertTrue(invitations.getItems().isEmpty());
         assertEquals(1, invitations.getItemsPerPage());


### PR DESCRIPTION
__Short description outlining key changes/additions__

fetchActiveInvitationsForUser was retrieving associations based on the userId, but did not account for userEmail. This meant that it would fail to retrieve some of the associations.

__JIRA Ticket Number__

IDVA6-1213

### Type of change

* [x] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__