### PR TITLE
Incorrect Redirects

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/association/mapper/AssociationsListMappers.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/mapper/AssociationsListMappers.java
@@ -43,7 +43,11 @@ public abstract class AssociationsListMappers extends AssociationMapper {
         final var endpointUrl = computeEndpointUrl( companyDetails );
         final var users = Objects.isNull( userDetails ) ? usersService.fetchUserDetails( associationsList.stream() ) : Map.of( userDetails.getUserId(), userDetails );
         final var companies = Objects.isNull( companyDetails ) ? companyService.fetchCompanyProfiles( associationsList.stream() ) : Map.of( companyDetails.getCompanyNumber(), companyDetails );
-        final var associations = associationsList.map( associationDao -> daoToDto( associationDao, users.getOrDefault( associationDao.getUserId(), null ), companies.get( associationDao.getCompanyNumber() ) ) );
+        final var associations = associationsList.map( associationDao -> {
+            final var user = Objects.isNull( associationDao.getUserId() ) ? null : users.getOrDefault( associationDao.getUserId(), null );
+            final var company = companies.get( associationDao.getCompanyNumber() );
+            return daoToDto( associationDao, user, company );
+        } );
         return enrichWithMetadata( associations, endpointUrl );
     }
 


### PR DESCRIPTION
__Short description outlining key changes/additions__

A ConcurrentHashMap does not work with null keys or values. This means it will crash when you call ConcurrentHashMap.getOrDefault(null).

We were calling ConcurrentHashMap.getOrDefault(userId), and userId was nullable in that context.

Fixed logic to prevent ConcurrentHashMap.getOrDefault method being called with null input.

__JIRA Ticket Number__

IDVA6-1559

### Type of change

* [x] Bug fix
* [ ] New feature
* [x] Breaking change
* [x] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__