### PR TITLE
SIV-275: Data Migration Invitations Update

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociation.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociation.java
@@ -21,7 +21,6 @@ import static uk.gov.companieshouse.api.accounts.associations.model.Association.
 import static uk.gov.companieshouse.accounts.association.utils.LoggingUtil.LOGGER;
 import static uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum.REMOVED;
 
-import java.util.Objects;
 import java.util.Optional;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.ResponseEntity;
@@ -121,7 +120,7 @@ public class UserCompanyAssociation implements UserCompanyAssociationInterface {
                 case CONFIRMED -> Optional.of( CONFIRMED )
                         .filter( status -> MIGRATED.equals( oldStatus ) )
                         .filter( status -> associationsService.confirmedAssociationExists( targetAssociation.getCompanyNumber(), getEricIdentity() ) )
-                        .map( status -> Objects.isNull( targetUser ) ? mapToInvitationUpdate( targetAssociation, targetUser, getEricIdentity(), now() ) : mapToConfirmedUpdate( targetAssociation, targetUser, getEricIdentity() ) )
+                        .map( status -> mapToInvitationUpdate( targetAssociation, targetUser, getEricIdentity(), now() ) )
                         .orElseThrow( () -> new BadRequestRuntimeException( "requesting user does not have access to perform the action", new Exception( String.format( "Requesting %s user cannot change another user to confirmed or the requesting user is not associated with company %s", getEricIdentity(), targetAssociation.getCompanyNumber() ) ) ) );
                 case REMOVED -> Optional.of( REMOVED )
                         .filter( status -> associationsService.confirmedAssociationExists( targetAssociation.getCompanyNumber(), getEricIdentity() ) || hasAdminPrivilege( ADMIN_UPDATE_PERMISSION ) )

--- a/src/test/java/uk/gov/companieshouse/accounts/association/integration/UserCompanyAssociationTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/integration/UserCompanyAssociationTest.java
@@ -572,16 +572,20 @@ class UserCompanyAssociationTest {
                 .andExpect( status().isOk() );
 
         final var updatedAssociation = associationsRepository.findById( "MKAssociation001" ).get();
+        final var invitation = updatedAssociation.getInvitations().getFirst();
 
-        Assertions.assertEquals( "confirmed", updatedAssociation.getStatus() );
-        Assertions.assertNotNull( updatedAssociation.getApprovedAt() );
         Assertions.assertNotNull( updatedAssociation.getEtag() );
         Assertions.assertEquals( 1, updatedAssociation.getPreviousStates().size() );
         Assertions.assertEquals( "migrated", updatedAssociation.getPreviousStates().getFirst().getStatus() );
         Assertions.assertEquals( "MKUser002", updatedAssociation.getPreviousStates().getFirst().getChangedBy() );
         Assertions.assertNotNull(  updatedAssociation.getPreviousStates().getFirst().getChangedAt() );
-        Assertions.assertNull( updatedAssociation.getUserEmail() );
         Assertions.assertEquals( "MKUser001", updatedAssociation.getUserId() );
+        Assertions.assertNull( updatedAssociation.getUserEmail() );
+        Assertions.assertEquals( "MKUser002", invitation.getInvitedBy() );
+        Assertions.assertNotNull( invitation.getInvitedAt() );
+        Assertions.assertNotNull( invitation.getExpiredAt() );
+        Assertions.assertEquals( "awaiting-approval", updatedAssociation.getStatus() );
+        Assertions.assertNotNull( updatedAssociation.getApprovalExpiryAt() );
     }
 
     @Test


### PR DESCRIPTION
__Short description outlining key changes/additions__

Updated PATCH endpoint. Now, when the RequestingUser attempts to confirm the TargetUsers migrated association, the TargetUser will receive an invitation, regardless of whether they have a CHS account.

__JIRA Ticket Number__

SIV-275

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__