### PR TITLE
SIV-697: Performance enhancements for Fetch Invitation Endpoints

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/association/configuration/ReactorRequestContextPropagation.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/configuration/ReactorRequestContextPropagation.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.accounts.association.configuration;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.scheduler.Schedulers;
+import uk.gov.companieshouse.accounts.association.models.context.RequestContext;
+
+@Configuration
+public class ReactorRequestContextPropagation {
+    private static final String HOOK_KEY = "request-context-propagation";
+
+    @PostConstruct
+    public void init() {
+        Schedulers.onScheduleHook(HOOK_KEY, original -> {
+            final var captured = RequestContext.getRequestContext();
+            return () -> {
+                final var previous = RequestContext.getRequestContext();
+                if (captured != null) {
+                    RequestContext.setRequestContext(captured);
+                } else {
+                    RequestContext.clear();
+                }
+                try {
+                    original.run();
+                } finally {
+                    if (previous != null) {
+                        RequestContext.setRequestContext(previous);
+                    } else {
+                        RequestContext.clear();
+                    }
+                }
+            };
+        });
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociation.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyAssociation.java
@@ -89,7 +89,7 @@ public class UserCompanyAssociation implements UserCompanyAssociationInterface {
                 .switchIfEmpty(Mono.error(new NotFoundRuntimeException(
                         PLEASE_CHECK_THE_REQUEST_AND_TRY_AGAIN,
                         new Exception(String.format("Could not find association %s.", associationId)))))
-                .blockOptional(Duration.ofSeconds(5))
+                .blockOptional(Duration.ofSeconds(20))
                 .orElseThrow(() -> new TimeOutException(
                         PLEASE_CHECK_THE_REQUEST_AND_TRY_AGAIN,
                         new Exception(String.format("Request for association %s timed out.", associationId))));

--- a/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyInvitations.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyInvitations.java
@@ -14,6 +14,7 @@ import static uk.gov.companieshouse.accounts.association.utils.StaticPropertyUti
 import static uk.gov.companieshouse.accounts.association.utils.UserUtil.mapToDisplayValue;
 import static uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum.CONFIRMED;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,13 +52,18 @@ public class UserCompanyInvitations implements UserCompanyInvitationsInterface {
     public ResponseEntity<InvitationsList> fetchActiveInvitationsForUser( final Integer pageIndex, final Integer itemsPerPage ) {
         LOGGER.infoContext( getXRequestId(), String.format( "Received request with user_id=%s, itemsPerPage=%d, pageIndex=%d.", getEricIdentity(), itemsPerPage, pageIndex ),null );
 
-        if ( pageIndex < 0 || itemsPerPage <= 0 ){
-            throw new BadRequestRuntimeException( PLEASE_CHECK_THE_REQUEST_AND_TRY_AGAIN, new Exception( PAGINATION_IS_MALFORMED ) );
+        if (pageIndex < 0 || itemsPerPage <= 0) {
+            throw new BadRequestRuntimeException(
+                    PLEASE_CHECK_THE_REQUEST_AND_TRY_AGAIN, new Exception(PAGINATION_IS_MALFORMED));
         }
 
-        final var invitations = associationsService.fetchActiveInvitations( getUser(), pageIndex, itemsPerPage );
+        final var response = Optional.ofNullable(associationsService
+                        .fetchActiveInvitations(getUser(), pageIndex, itemsPerPage))
+                .flatMap(Mono::blockOptional)
+                .orElseGet(() -> new InvitationsList().items(Collections.emptyList()));
 
-        return new ResponseEntity<>( invitations, OK );
+        return new ResponseEntity<>(response, OK);
+
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/accounts/association/exceptions/TimeOutException.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/association/exceptions/TimeOutException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.accounts.association.exceptions;
+
+import static uk.gov.companieshouse.accounts.association.utils.LoggingUtil.LOGGER;
+import static uk.gov.companieshouse.accounts.association.utils.RequestContextUtil.getXRequestId;
+
+public class TimeOutException extends RuntimeException {
+
+    public TimeOutException( final String exceptionMessage, final Exception loggingMessage) {
+        super( exceptionMessage );
+        LOGGER.errorContext( getXRequestId(), loggingMessage, null );
+    }
+
+}
+
+

--- a/src/test/java/uk/gov/companieshouse/accounts/association/common/TestDataManager.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/common/TestDataManager.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.accounts.association.models.AssociationDao;
 import uk.gov.companieshouse.accounts.association.models.InvitationDao;
 import uk.gov.companieshouse.accounts.association.models.PreviousStatesDao;
@@ -1630,4 +1631,8 @@ public class TestDataManager {
                 .collect( Collectors.toList() );
     }
 
+    public static <T> T block(Mono<T> mono) {
+        return mono.blockOptional()
+                .orElseThrow(() -> new AssertionError("Mono was empty"));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/accounts/association/configuration/ReactorRequestContextPropagationTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/configuration/ReactorRequestContextPropagationTest.java
@@ -1,0 +1,78 @@
+package uk.gov.companieshouse.accounts.association.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+import uk.gov.companieshouse.accounts.association.models.context.RequestContext;
+import uk.gov.companieshouse.accounts.association.models.context.RequestContextData;
+
+class ReactorRequestContextPropagationTest {
+
+    @BeforeAll
+    static void setupHook() {
+        new ReactorRequestContextPropagation().init();
+    }
+
+    private static RequestContextData makeContext(String requestId) {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getHeader("X-Request-Id")).thenReturn(requestId);
+        return new RequestContextData.RequestContextDataBuilder().setXRequestId(mockRequest).build();
+    }
+
+    @Test
+    void contextShouldSurviveFluxPipeline() {
+        final var requestId = "req-" + UUID.randomUUID();
+        RequestContext.setRequestContext(makeContext(requestId));
+
+        final var seenIds = Flux.fromIterable(IntStream.range(0, 10).boxed().toList()).flatMapSequential(
+                i -> Flux.defer(() -> {
+                    var ctx = RequestContext.getRequestContext();
+                    return Flux.just(ctx != null ? ctx.getXRequestId() : "missing");
+                }).subscribeOn(Schedulers.boundedElastic())).collectList().block();
+
+        RequestContext.clear();
+
+        assertThat(seenIds).containsOnly(requestId);
+    }
+
+    @Test
+    void manyConcurrentRequestsShouldNotLeakContexts() {
+        final var numberOfRequests = 500;
+        final var numberOfThreads = 50;
+
+        try (ExecutorService pool = Executors.newFixedThreadPool(numberOfThreads)) {
+            List<CompletableFuture<Boolean>> futures = IntStream.range(0, numberOfRequests).mapToObj(
+                    i -> CompletableFuture.supplyAsync(() -> {
+                        final var requestId = "req-" + UUID.randomUUID();
+                        RequestContext.setRequestContext(makeContext(requestId));
+                        try {
+                            List<String> seenIds = Flux.range(1, 30).flatMap(j -> Flux.defer(() -> {
+                                final var ctx = RequestContext.getRequestContext();
+                                return Flux.just(ctx != null ? ctx.getXRequestId() : "missing");
+                            }).subscribeOn(Schedulers.boundedElastic())).collectList().block();
+
+                            return seenIds.stream().allMatch(requestId::equals);
+                        } finally {
+                            RequestContext.clear();
+                        }
+                    }, pool)).toList();
+
+            final var results = futures.stream().map(CompletableFuture::join).toList();
+
+            assertThat(results).isNotEmpty();
+            assertThat(results).allMatch(r -> r);
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyInvitationsTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/association/controller/UserCompanyInvitationsTest.java
@@ -11,9 +11,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.accounts.association.common.ParsingUtils.parseResponseTo;
-import static uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil.DAYS_SINCE_INVITE_TILL_EXPIRES;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,10 +22,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -37,15 +35,11 @@ import uk.gov.companieshouse.accounts.association.common.Mockers;
 import uk.gov.companieshouse.accounts.association.common.TestDataManager;
 import uk.gov.companieshouse.accounts.association.configuration.WebSecurityConfig;
 import uk.gov.companieshouse.accounts.association.exceptions.BadRequestRuntimeException;
-import uk.gov.companieshouse.accounts.association.models.InvitationDao;
-import uk.gov.companieshouse.accounts.association.models.PreviousStatesDao;
 import uk.gov.companieshouse.accounts.association.service.AssociationsService;
 import uk.gov.companieshouse.accounts.association.service.CompanyService;
 import uk.gov.companieshouse.accounts.association.service.EmailService;
 import uk.gov.companieshouse.accounts.association.service.UsersService;
 import uk.gov.companieshouse.accounts.association.utils.StaticPropertyUtil;
-import uk.gov.companieshouse.api.accounts.associations.model.Association.ApprovalRouteEnum;
-import uk.gov.companieshouse.api.accounts.associations.model.Association.StatusEnum;
 import uk.gov.companieshouse.api.accounts.associations.model.InvitationsList;
 import uk.gov.companieshouse.api.accounts.associations.model.Links;
 
@@ -60,19 +54,19 @@ class UserCompanyInvitationsTest {
     @Autowired
     private WebApplicationContext context;
 
-    @MockBean
+    @MockitoBean
     private StaticPropertyUtil staticPropertyUtil;
 
-    @MockBean
+    @MockitoBean
     private UsersService usersService;
 
-    @MockBean
+    @MockitoBean
     private CompanyService companyService;
 
-    @MockBean
+    @MockitoBean
     private AssociationsService associationsService;
 
-    @MockBean
+    @MockitoBean
     private EmailService emailService;
 
     final Function<String, Mono<Void>> sendEmailMock = userId -> Mono.empty();
@@ -190,7 +184,7 @@ class UserCompanyInvitationsTest {
                 .itemsPerPage(1).pageNumber(1).totalResults(2).totalPages(2);
 
         mockers.mockUsersServiceFetchUserDetails( "000" );
-        when(associationsService.fetchActiveInvitations(user, 1,1)).thenReturn(mockInvitationsList);
+        when(associationsService.fetchActiveInvitations(user, 1,1)).thenReturn(Mono.just(mockInvitationsList));
 
         final var response = mockMvc.perform(get("/associations/invitations?page_index=1&items_per_page=1")
                         .header("X-Request-Id", "theId123")


### PR DESCRIPTION
__Short description outlining key changes/additions__
The purpose of this PR is to attempt to speed up the `GET /associations/{id}/invitations` and `GET /associations/invitations` by using `Flux` instead of `Stream`.

A few notable changes:
- I have created the class `ReactorRequestContextPropagation` which ensures that request-scoped values such as `X-Request-Id` will remain available throughout the reactive pipeline
- I have rewritten the test `daoToDtoCorrectlyMapsAssociationToInvitationsList()` originally this was done simply because I believed that we would not be preserving the order. However as it is at the moment it now tests specifically for the results not being in order so it can be more easily identified if there is an issue.

__JIRA Ticket Number__

[SIV-697: Performance enhancements for Fetch Invitation Endpoints](https://companieshouse.atlassian.net/browse/SIV-697)

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__